### PR TITLE
DE-3718 update permission check

### DIFF
--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -137,6 +137,7 @@
   (cond
     (empty? query)                   #{}
     (= (keyword query-type) :native) #{(perms/adhoc-native-query-path database)}
+    (= (keyword query-type) :view #{(perms/all-schemas-path database)}
     (= (keyword query-type) :query)  (mbql-permissions-path-set query perms-opts)
     :else                            (throw (Exception. (tru "Invalid query type: {0}" query-type)))))
 

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -137,7 +137,7 @@
   (cond
     (empty? query)                   #{}
     (= (keyword query-type) :native) #{(perms/adhoc-native-query-path database)}
-    (= (keyword query-type) :view #{(perms/all-schemas-path database)}
+    (= (keyword query-type) :view #{(perms/all-schemas-path database)} ; => /database/id/schema
     (= (keyword query-type) :query)  (mbql-permissions-path-set query perms-opts)
     :else                            (throw (Exception. (tru "Invalid query type: {0}" query-type)))))
 

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -50,7 +50,9 @@
   (when *current-user-id*
     (log/tracef "Checking query permissions. Current user perms set = %s" (pr-str @*current-user-permissions-set*))
     (if card-id
-      (and (check-card-read-perms card-id) (check-ad-hoc-query-perms outer-query))
+      (do
+        (check-card-read-perms card-id)
+        (check-ad-hoc-query-perms outer-query))
       (check-ad-hoc-query-perms outer-query))))
 
 (defn check-query-permissions

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -50,7 +50,7 @@
   (when *current-user-id*
     (log/tracef "Checking query permissions. Current user perms set = %s" (pr-str @*current-user-permissions-set*))
     (if card-id
-      (check-card-read-perms card-id)
+      (and (check-card-read-perms card-id) (check-ad-hoc-query-perms outer-query))
       (check-ad-hoc-query-perms outer-query))))
 
 (defn check-query-permissions


### PR DESCRIPTION
Before changes: Metabase only checks permissions to read cards when users open a question or dashboard.

After changes: Metabase will checks both permissions to read cards and underlying datasources.

When an user is given data access permission:

<img width="226" alt="Screenshot 2020-06-23 at 23 28 30" src="https://user-images.githubusercontent.com/4472857/85472059-43370080-b5a9-11ea-9795-f9cbd866c5c8.png">

they are granted a permission path in a form of `/database/id/schema`

I invented a new query type named: `:view`, referring to the queries in saved questions (`when card-id is not nil`). This instructs the program to return the required permission to view a saved questions is `/database/id/schema`.

A new function `check-data-access-perms` is implemented to check the permissions by compare `required_perms` vs  `current-user-permissions-set`