### PR TITLE
DE-3818 Reduce log message

### DIFF
--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -30,7 +30,6 @@
   (ex-info (tru "Sorry, you do not have permission to access this database.")
     {:type                 error-type/missing-required-permissions
      :required-permissions required-perms
-     :actual-permissions   @*current-user-permissions-set*
      :permissions-error?   true}))
 
 (declare check-query-permissions*)


### PR DESCRIPTION
`current-user-permissions-set` is a very long set, it produces huge log message.
