### PR TITLE
DE-3858 Enable caching /api/collection/root/items endpoint for 24 hours

### DIFF
--- a/src/metabase/middleware/util.clj
+++ b/src/metabase/middleware/util.clj
@@ -35,4 +35,6 @@
   "Can the ring request be privately cached?"
   [{:keys [uri query-string], :as request}]
   ;; cache /api/database requests
-  (re-matches #"^/api/database.*" uri))
+  (or
+   (re-matches #"^/api/database.*" uri))
+   (re-matches #"^/api/collection/root/items$" uri))


### PR DESCRIPTION
`/api/collection/root/items` is endpoint is slow because the underlying heavy db call and it's not being changed very often. So We can cache it for 24 hours