### PR TITLE
DE-4741 cache /api/database?include=tables for 24 hours

### DIFF
--- a/src/metabase/middleware/util.clj
+++ b/src/metabase/middleware/util.clj
@@ -44,5 +44,6 @@
   [{:keys [uri query-string], :as request}]
   ;; cache /api/database/\d+/metadata and /api/collection/root/items requests
   (or
+   (re-matches #"^/api/database\?include=tables$" (str uri "?" query-string))
    (re-matches #"^/api/collection/root/items$" uri)
    (re-matches #"^/api/database/\d+/metadata$" uri)))


### PR DESCRIPTION
- Cache /api/database?include=tables endpoint for 24 hours