### PR TITLE
DE-4742 Optimize permissions check

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -38,6 +38,9 @@
   "Delay to the set of permissions granted to the current user."
   (atom #{}))
 
+(def ^:dynamic *current-db-permissions-set*
+  "Delay to the set of db permissions granted to the current user."
+  (atom #{}))
 
 ;;; ---------------------------------------- Precondition checking helper fns ----------------------------------------
 

--- a/src/metabase/middleware/security.clj
+++ b/src/metabase/middleware/security.clj
@@ -106,10 +106,10 @@
   (merge
    (if allow-cache?
      (cache-far-future-headers)
-     (if allow-2h-cache?
-       (cache-2h-headers)
-       (if allow-24h-cache?
-        (cache-24h-headers)
+     (if allow-24h-cache?
+       (cache-24h-headers)
+       (if allow-2h-cache?
+        (cache-2h-headers)
         (cache-prevention-headers))))
    strict-transport-security-header
    content-security-policy-header

--- a/src/metabase/middleware/session.clj
+++ b/src/metabase/middleware/session.clj
@@ -5,7 +5,9 @@
             [metabase
              [config :as config]
              [db :as mdb]]
-            [metabase.api.common :refer [*current-user* *current-user-id* *current-user-permissions-set* *is-superuser?*]]
+            [metabase.api.common :refer [*current-user* *current-user-id*
+                                         *current-user-permissions-set* *current-db-permissions-set*
+                                         *is-superuser?*]]
             [metabase.core.initialization-status :as init-status]
             [metabase.models
              [session :refer [Session]]
@@ -180,6 +182,7 @@
   (binding [*current-user-id*              current-user-id
             *is-superuser?*                (boolean superuser?)
             *current-user*                 (delay (find-user current-user-id))
+            *current-db-permissions-set*   (delay (some-> current-user-id user/db-permissions-set))
             *current-user-permissions-set* (delay (some-> current-user-id user/permissions-set))]
     (thunk)))
 

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -289,3 +289,14 @@
                                   :join   [[:permissions_group :pg] [:= :pgm.group_id :pg.id]
                                            [:permissions :p]        [:= :p.group_id :pg.id]]
                                   :where  [:= :pgm.user_id user-id]}))))))
+
+(defn db-permissions-set
+  "Return a set of all permissions object paths that `user-or-id` has been granted access to. (2 DB Calls)"
+  [user-or-id]
+  (set (when-let [user-id (u/get-id user-or-id)]
+          ;; include the other Perms entries for any Group this User is in (1 DB Call)
+         (map :object (db/query {:select [:p.object]
+                                  :from   [[:permissions_group_membership :pgm]]
+                                  :join   [[:permissions_group :pg] [:= :pgm.group_id :pg.id]
+                                           [:permissions :p]        [:= :p.group_id :pg.id]]
+                                  :where  [:= :pgm.user_id user-id]})))))

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.middleware.permissions
   "Middleware for checking that the current user has permissions to run the current query."
   (:require [clojure.tools.logging :as log]
-            [metabase.api.common :refer [*current-user-id* *current-user-permissions-set*]]
+            [metabase.api.common :refer [*current-user-id* *current-user-permissions-set* *current-db-permissions-set*]]
             [metabase.models
              [card :refer [Card]]
              [interface :as mi]
@@ -47,7 +47,7 @@
   [outer-query]
   (let [required-perms (query-perms/perms-set outer-query, :throw-exceptions? true, :already-preprocessed? true)]
     (log/tracef "Required data acscess perms: %s" (pr-str required-perms))
-    (when-not (perms/set-has-full-permissions-for-set? @*current-user-permissions-set* required-perms)
+    (when-not (perms/set-has-full-permissions-for-set? @*current-db-permissions-set* required-perms)
       (throw (perms-exception required-perms)))))
 
 (s/defn ^:private check-query-permissions*


### PR DESCRIPTION
Metabase validates permissions by comparing required permissions with a set of granted permissions. The default `permissions-set` requires 2 db calls, 1 for collection permissions and 1 for db permissions.

Recently, we have introduced data access permissions, which also uses this permissions-set to validate permissions. It causes performance issue because of too many DB calls.

This PR introduces `db-permisions-set` which requires 1 DB call to verify permissions.