### PR TITLE
Add url to the error message

### DIFF
--- a/frontend/src/metabase/containers/ErrorPages.jsx
+++ b/frontend/src/metabase/containers/ErrorPages.jsx
@@ -53,7 +53,7 @@ export const NotFound = () => (
 export const Unauthorized = () => (
   <ErrorPageWrapper>
     <EmptyState
-      title={t`Sorry, you don’t have permission to view the content of this collection.`}
+      title={t`Sorry, you don’t have permission to view the content of this collection. Please see https://revolut.atlassian.net/wiki/spaces/BD/pages/1593568569/Requesting+Access+for+Metabase+Permissions for more information`}
       illustrationElement={<Icon name="key" size={100} />}
     />
   </ErrorPageWrapper>

--- a/frontend/src/metabase/containers/ErrorPages.jsx
+++ b/frontend/src/metabase/containers/ErrorPages.jsx
@@ -53,7 +53,7 @@ export const NotFound = () => (
 export const Unauthorized = () => (
   <ErrorPageWrapper>
     <EmptyState
-      title={t`Sorry, you don’t have permission to view the content of this collection. Please see https://revolut.atlassian.net/wiki/spaces/BD/pages/1593568569/Requesting+Access+for+Metabase+Permissions for more information`}
+      title={t`Sorry, you don’t have permission to view the content of this collection. Please see https://revolut.atlassian.net/wiki/x/Oe37Xg for more information.`}
       illustrationElement={<Icon name="key" size={100} />}
     />
   </ErrorPageWrapper>

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -36,8 +36,8 @@ import _ from "underscore";
 import cx from "classnames";
 
 export const ERROR_MESSAGE_GENERIC = t`There was a problem displaying this chart.`;
-export const ERROR_MESSAGE_PERMISSION = t`Sorry, you don't have permission to see this card. See https://revolut.atlassian.net/wiki/spaces/BD/pages/1593568569/Requesting+Access+for+Metabase+Permissions for more information`;
-export const ERROR_MESSAGE_DB_PERMISSION = t`Sorry, you don't have permission to access this database. Please see https://revolut.atlassian.net/wiki/spaces/BD/pages/1593568569/Requesting+Access+for+Metabase+Permissions for more information`;
+export const ERROR_MESSAGE_PERMISSION = t`Sorry, you don't have permission to see this card. Please see https://revolut.atlassian.net/wiki/x/Oe37Xg for more information.`;
+export const ERROR_MESSAGE_DB_PERMISSION = t`Sorry, you don't have permission to access this database. Please see https://revolut.atlassian.net/wiki/x/Oe37Xg for more information.`;
 
 import Question from "metabase-lib/lib/Question";
 import Mode from "metabase-lib/lib/Mode";

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -36,8 +36,8 @@ import _ from "underscore";
 import cx from "classnames";
 
 export const ERROR_MESSAGE_GENERIC = t`There was a problem displaying this chart.`;
-export const ERROR_MESSAGE_PERMISSION = t`Sorry, you don't have permission to see this card.`;
-export const ERROR_MESSAGE_DB_PERMISSION = t`Sorry, you don't have permission to access this database.`;
+export const ERROR_MESSAGE_PERMISSION = t`Sorry, you don't have permission to see this card. See https://revolut.atlassian.net/wiki/spaces/BD/pages/1593568569/Requesting+Access+for+Metabase+Permissions for more information`;
+export const ERROR_MESSAGE_DB_PERMISSION = t`Sorry, you don't have permission to access this database. Please see https://revolut.atlassian.net/wiki/spaces/BD/pages/1593568569/Requesting+Access+for+Metabase+Permissions for more information`;
 
 import Question from "metabase-lib/lib/Question";
 import Mode from "metabase-lib/lib/Mode";


### PR DESCRIPTION
Just to avoid people being confused and reduce pain, redirect people to the internal confluence page to action the error.