### PR TITLE
DPL-75 Control different helios connection pool sizes

### DIFF
--- a/modules/drivers/exasol/resources/metabase-plugin.yaml
+++ b/modules/drivers/exasol/resources/metabase-plugin.yaml
@@ -25,6 +25,9 @@ driver:
     - name: querytimeout
       display-name: Query timeout
       default: 180
+    - name: connection_pool
+      display-name: Connection pool
+      default: 10
   connection-properties-include-tunnel-config: true
 init:
   - step: load-namespace

--- a/modules/drivers/exasol/src/metabase/driver/exasol.clj
+++ b/modules/drivers/exasol/src/metabase/driver/exasol.clj
@@ -157,10 +157,10 @@
    "minPoolSize"                  1
    "initialPoolSize"              1
    "maxPoolSize"                  (cond
-                                    (= (spec :user) "metabase") (or (config/config-int :helios-connection-pool-size) 20)
-                                    (= (spec :user) "metabase_plus") (or (config/config-int :helios-plus-connection-pool-size) 20)
-                                    (= (spec :user) "metabase_finance") (or (config/config-int :helios-finance-connection-pool-size) 20)
-                                    :else 5)
+                                    (= (spec :user) "metabase") (or (config/config-int :helios-connection-pool-size) 10)
+                                    (= (spec :user) "metabase_plus") (or (config/config-int :helios-plus-connection-pool-size) 10)
+                                    (= (spec :user) "metabase_finance") (or (config/config-int :helios-finance-connection-pool-size) 10)
+                                    :else 10)
    "testConnectionOnCheckout"     true
    "maxIdleTimeExcessConnections" (* 15 60)})
 

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -44,7 +44,7 @@
   :hierarchy #'driver/hierarchy)
 
 (defmethod data-warehouse-connection-pool-properties :default
-  [_]
+  [_ spec]
   { ;; only fetch one new connection at a time, rather than batching fetches (default = 3 at a time). This is done in
    ;; interest of minimizing memory consumption
    "acquireIncrement"             1
@@ -86,7 +86,7 @@
   (log/debug (u/format-color 'cyan (trs "Creating new connection pool for {0} database {1} ..." driver id)))
   (let [details-with-tunnel (ssh/include-ssh-tunnel details) ;; If the tunnel is disabled this returned unchanged
         spec                (connection-details->spec driver details-with-tunnel)
-        properties          (data-warehouse-connection-pool-properties driver)]
+        properties          (data-warehouse-connection-pool-properties driver spec)]
     (connection-pool/connection-pool-spec spec properties)))
 
 (defn- destroy-pool! [database-id pool-spec]


### PR DESCRIPTION
Helios connection pool is configurable on admin page. Default is set to 10 for new connections.