### PR TITLE
DPL-221 Fix google auth when throttling is disabled

### DIFF
--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -344,7 +344,7 @@
     (throw (ex-info "Google Auth is disabled." {:status-code 400})))
   ;; Verify the token is valid with Google
   (if throttling-disabled?
-    (do-google-auth token)
+    (do-google-auth request)
     (http-400-on-error
       (throttle/with-throttling [(login-throttlers :ip-address) (source-address request)]
         (do-google-auth request)))))


### PR DESCRIPTION
This fixes a bug that breaks google auth when session throttling is disabled via env var (compare with L350 in the same file)